### PR TITLE
bump `tqdm` version

### DIFF
--- a/recipes/tqdm_async.py
+++ b/recipes/tqdm_async.py
@@ -21,7 +21,7 @@ async def download_all_sites(sites):
         tasks = []
         for url in sites:
             tasks.append(download_site(session, url))
-        result = await tqdm.gather(tasks)
+        result = await tqdm.gather(*tasks)
         # result = [
         #     await f
         #     for f in tqdm(asyncio.as_completed(tasks), total=len(tasks))

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,5 +18,5 @@ pytest-flake8
 pytest-xdist
 requests
 sh
-tqdm
+tqdm>=4.62.0
 yaspin


### PR DESCRIPTION
New `tqdm.asyncio.tqdm.gather` syntax ([`tqdm>=4.62.0`](https://tqdm.github.io/releases/#v4620-2021-07-30) <- https://github.com/tqdm/tqdm/pull/1209 <- https://github.com/tqdm/tqdm/pull/1212)